### PR TITLE
Enable GPU support

### DIFF
--- a/grid_search_weight_adjust.py
+++ b/grid_search_weight_adjust.py
@@ -29,8 +29,9 @@ from optimize import *
 
 torch.backends.cudnn.deterministic = True
 torch.backends.cudnn.benchmark = False
-
-device = torch.device("cpu")
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+if device.type == "cuda":
+    torch.cuda.manual_seed(config["seed"])
 
 Dataset = pd.read_csv(config["data"]).set_index("date")
 Dataset = drop_columns_with_many_nans(Dataset, threshold=0.2)
@@ -64,7 +65,7 @@ def split_range(Dataset: pd.DataFrame, split_date_from: str, split_date_to: str)
     
     data = Dataset.loc[mask]
     data = np.array(data)
-    data = torch.from_numpy(data).float()
+    data = torch.from_numpy(data).float().to(device)
 
     dates = Dataset.loc[mask].index
 
@@ -72,7 +73,7 @@ def split_range(Dataset: pd.DataFrame, split_date_from: str, split_date_to: str)
     index_end = len(Dataset.loc[Dataset.index <= split_date_to])
     index_ = index[index_start:index_end]
     index_ = np.array(index_)
-    index_ = torch.from_numpy(index_).float()
+    index_ = torch.from_numpy(index_).float().to(device)
 
     assert data.shape[0] == index_.shape[0]
     return data, index_, dates

--- a/main.py
+++ b/main.py
@@ -35,9 +35,10 @@ torch.backends.cudnn.deterministic = True
 torch.backends.cudnn.benchmark = False
 np.random.seed(config["seed"])
 torch.manual_seed(config["seed"])
-torch.cuda.manual_seed(config["seed"])
+if torch.cuda.is_available():
+    torch.cuda.manual_seed(config["seed"])
 
-device = torch.device("cpu")
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 Dataset = pd.read_csv(config["data"]).set_index("date")
 Dataset = drop_columns_with_many_nans(Dataset, threshold=0.2)
@@ -82,7 +83,7 @@ def split_range(Dataset: pd.DataFrame, split_date_from: str, split_date_to: str)
     mask = (Dataset.index >= previous_date) & (Dataset.index < split_date_to)
     data = Dataset.loc[mask]
     data = np.array(data)
-    data = torch.from_numpy(data).float()
+    data = torch.from_numpy(data).float().to(device)
 
     dates = Dataset.loc[mask].index
     
@@ -91,7 +92,7 @@ def split_range(Dataset: pd.DataFrame, split_date_from: str, split_date_to: str)
     index_end = len(Dataset.loc[Dataset.index < split_date_to])
     index_ = index[index_start:index_end]
     index_ = np.array(index_)
-    index_ = torch.from_numpy(index_).float()
+    index_ = torch.from_numpy(index_).float().to(device)
 
     assert data.shape[0] == index_.shape[0]
     return data, index_, dates

--- a/main_seeds.py
+++ b/main_seeds.py
@@ -73,9 +73,10 @@ torch.backends.cudnn.deterministic = True
 torch.backends.cudnn.benchmark = False
 # np.random.seed(config["seed"])
 # torch.manual_seed(config["seed"])
-# torch.cuda.manual_seed(config["seed"])
+if torch.cuda.is_available():
+    torch.cuda.manual_seed(config["seed"])
 
-device = torch.device("cpu")
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 Dataset = pd.read_csv(config["data"]).set_index("date")
 Dataset = drop_columns_with_many_nans(Dataset, threshold=0.2)
@@ -111,7 +112,7 @@ def split_range(Dataset: pd.DataFrame, split_date_from: str, split_date_to: str)
     
     data = Dataset.loc[mask]
     data = np.array(data)
-    data = torch.from_numpy(data).float()
+    data = torch.from_numpy(data).float().to(device)
 
     dates = Dataset.loc[mask].index
 
@@ -119,7 +120,7 @@ def split_range(Dataset: pd.DataFrame, split_date_from: str, split_date_to: str)
     index_end = len(Dataset.loc[Dataset.index <= split_date_to])
     index_ = index[index_start:index_end]
     index_ = np.array(index_)
-    index_ = torch.from_numpy(index_).float()
+    index_ = torch.from_numpy(index_).float().to(device)
 
     assert data.shape[0] == index_.shape[0]
     return data, index_, dates

--- a/main_seeds_diff_holding.py
+++ b/main_seeds_diff_holding.py
@@ -46,9 +46,10 @@ torch.backends.cudnn.deterministic = True
 torch.backends.cudnn.benchmark = False
 # np.random.seed(config["seed"])
 # torch.manual_seed(config["seed"])
-# torch.cuda.manual_seed(config["seed"])
+if torch.cuda.is_available():
+    torch.cuda.manual_seed(config["seed"])
 
-device = torch.device("cpu")
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 Dataset = pd.read_csv(config["data"]).set_index("date")
 Dataset = drop_columns_with_many_nans(Dataset, threshold=0.2)
@@ -82,7 +83,7 @@ def split_range(Dataset: pd.DataFrame, split_date_from: str, split_date_to: str)
     
     data = Dataset.loc[mask]
     data = np.array(data)
-    data = torch.from_numpy(data).float()
+    data = torch.from_numpy(data).float().to(device)
 
     dates = Dataset.loc[mask].index
 
@@ -90,7 +91,7 @@ def split_range(Dataset: pd.DataFrame, split_date_from: str, split_date_to: str)
     index_end = len(Dataset.loc[Dataset.index <= split_date_to])
     index_ = index[index_start:index_end]
     index_ = np.array(index_)
-    index_ = torch.from_numpy(index_).float()
+    index_ = torch.from_numpy(index_).float().to(device)
 
     assert data.shape[0] == index_.shape[0]
     return data, index_, dates

--- a/predict.py
+++ b/predict.py
@@ -22,10 +22,11 @@ torch.backends.cudnn.deterministic = True
 torch.backends.cudnn.benchmark = False
 np.random.seed(config["seed"])
 torch.manual_seed(config["seed"])
-torch.cuda.manual_seed(config["seed"])
+if torch.cuda.is_available():
+    torch.cuda.manual_seed(config["seed"])
 
 
-device = torch.device("cpu")
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 # Load dataset
 Dataset = pd.read_csv(config["data"]).set_index("date")
@@ -55,10 +56,10 @@ def split_range(Dataset: pd.DataFrame):
     """
 
     data = np.array(Dataset)
-    data = torch.from_numpy(data).float()
+    data = torch.from_numpy(data).float().to(device)
 
     index_ = np.array(index)
-    index_ = torch.from_numpy(index_).float()
+    index_ = torch.from_numpy(index_).float().to(device)
 
     dates = Dataset.index
     assert data.shape[0] == index_.shape[0]

--- a/seed.py
+++ b/seed.py
@@ -22,7 +22,9 @@ torch.manual_seed(config["seed"])
 torch.cuda.manual_seed(config["seed"])
 '''
 
-device = torch.device("cpu")
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+if device.type == "cuda":
+    torch.cuda.manual_seed(config["seed"])
 
 # Load dataset
 Dataset = pd.read_csv(config["data"]).set_index("date")
@@ -47,13 +49,13 @@ def split_range(Dataset: pd.DataFrame, split_date_from: str, split_date_to: str)
     mask = (Dataset.index >= split_date_from) & (Dataset.index < split_date_to)
     data = Dataset.loc[mask]
     data = np.array(data)
-    data = torch.from_numpy(data).float()
+    data = torch.from_numpy(data).float().to(device)
 
     index_start = len(Dataset.loc[Dataset.index < split_date_from])
     index_end = len(Dataset.loc[Dataset.index < split_date_to])
     index_ = index[index_start:index_end]
     index_ = np.array(index_)
-    index_ = torch.from_numpy(index_).float()
+    index_ = torch.from_numpy(index_).float().to(device)
 
     dates = Dataset.loc[mask].index
     assert data.shape[0] == index_.shape[0]

--- a/train.py
+++ b/train.py
@@ -212,7 +212,7 @@ def train_and_test_for_combined_weight(train_data: torch.tensor,
     
     holding_weights = None
     if previous_pf is not None:
-      holding_weights = torch.tensor(previous_pf.weights.values, dtype=torch.float).unsqueeze(0)
+      holding_weights = torch.tensor(previous_pf.weights.values, dtype=torch.float, device=device).unsqueeze(0)
     
     
     for start_trading_weight in start_trading_weight_candidates:  # MODIFIED
@@ -364,7 +364,7 @@ def train_and_test_for_combined_weight_Lagrangian(train_data: torch.tensor,
     holding_weights = None
     expanded_holding_assets = None
     if previous_pf is not None:
-      holding_weights = torch.tensor(previous_pf.weights.values, dtype=torch.float).unsqueeze(0)
+      holding_weights = torch.tensor(previous_pf.weights.values, dtype=torch.float, device=device).unsqueeze(0)
       expanded_holding_assets = holding_weights[:, :len(assets)].expand(config["batch"], -1)  # shape: [batch, num_assets]
     
     

--- a/weight_adjust.py
+++ b/weight_adjust.py
@@ -30,8 +30,9 @@ from load_price import *
 
 torch.backends.cudnn.deterministic = True
 torch.backends.cudnn.benchmark = False
-
-device = torch.device("cpu")
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+if device.type == "cuda":
+    torch.cuda.manual_seed(config["seed"])
 
 Dataset = pd.read_csv(config["data"]).set_index("date")
 Dataset = drop_columns_with_many_nans(Dataset, threshold=0.2)
@@ -65,7 +66,7 @@ def split_range(Dataset: pd.DataFrame, split_date_from: str, split_date_to: str)
     
     data = Dataset.loc[mask]
     data = np.array(data)
-    data = torch.from_numpy(data).float()
+    data = torch.from_numpy(data).float().to(device)
 
     dates = Dataset.loc[mask].index
 
@@ -73,7 +74,7 @@ def split_range(Dataset: pd.DataFrame, split_date_from: str, split_date_to: str)
     index_end = len(Dataset.loc[Dataset.index <= split_date_to])
     index_ = index[index_start:index_end]
     index_ = np.array(index_)
-    index_ = torch.from_numpy(index_).float()
+    index_ = torch.from_numpy(index_).float().to(device)
 
     assert data.shape[0] == index_.shape[0]
     return data, index_, dates


### PR DESCRIPTION
## Summary
- make scripts automatically select CUDA when available and move tensors to the active device
- register LSTM hidden states as module buffers to follow device placement
- ensure portfolio weight tensors from previous runs reside on the proper device

## Testing
- `python -m py_compile model.py grid_search_weight_adjust.py main.py main_seeds.py main_seeds_diff_holding.py predict.py seed.py train.py weight_adjust.py`


------
https://chatgpt.com/codex/tasks/task_e_688de4568948832c8fc7fc596a183b42